### PR TITLE
PR: Fix Update Publication API #17

### DIFF
--- a/apps/posts/serializers/publication.py
+++ b/apps/posts/serializers/publication.py
@@ -59,9 +59,10 @@ class PublicationUpdateSerializer(Serializer):
         validators=[
             FileExtensionValidator(IMAGE_EXTENSION),
         ],
+        required=False,
     )
     description = srz.CharField(
         help_text="Description",
-        required=True,
         max_length=100,
+        required=False,
     )

--- a/apps/posts/services/publication.py
+++ b/apps/posts/services/publication.py
@@ -88,7 +88,7 @@ def create_publication(*, request_user: User, fields: _PubContextT) -> Publicati
         # Create preliminar instance.
         publication = Publication(
             code=fn.generate_random_code(),
-            description=fields["description"],
+            description=fields.get("description", ""),
             user=user,
             image="",
         )


### PR DESCRIPTION
closed #17
------------------
issue #17

- Make the image field optional when updating a pub.
- Ensure the API allows updating other fields without requiring an image.